### PR TITLE
[FIX] Assert on equality, not truthiness of test payload (false positive)

### DIFF
--- a/test/test-api-paths.js
+++ b/test/test-api-paths.js
@@ -19,7 +19,7 @@ export default () => {
       },
     });
 
-    assert(generatedTests, expected, 'generated source matched expected source');
+    assert.equal(generatedTests, expected, 'generated source matched expected source');
   });
 
   it('path should work when using a string', () => {


### PR DESCRIPTION
This actually runs the test. Previously, the assertion wasn't actually testing against expected output, it was just asserting that there was output.
